### PR TITLE
Fix for nil panic on malformed img src value

### DIFF
--- a/recon.go
+++ b/recon.go
@@ -381,7 +381,12 @@ func (p *Parser) analyzeImages(baseURL *url.URL, tags []imgTag) []Image {
 
 	for _, tag := range tags {
 		go func(tag imgTag, ch chan parsedImage) {
-			u, _ := url.Parse(tag.url)
+			u, err := url.Parse(tag.url)
+			if err != nil {
+				// malformed image src
+				ch <- parsedImage{}
+				return
+			}
 			u = baseURL.ResolveReference(u)
 
 			if strings.HasPrefix(u.String(), "data:") {

--- a/recon_test.go
+++ b/recon_test.go
@@ -59,6 +59,31 @@ func testParse(t *testing.T, url string, local string, parseImages bool, expecte
 	}
 }
 
+func TestParseMalformed(t *testing.T) {
+	testParse(
+		t,
+		"http://localhost/malformed-url-test.html",
+		"test-html/malformed-url-test.html",
+		true,
+		Result{
+			Title:  `Test Malformed URL`,
+			Site:   ``,
+			Author: ``,
+			Images: []Image{
+				{
+					URL:         "",
+					Type:        "",
+					Alt:         "",
+					Width:       0,
+					Height:      0,
+					AspectRatio: 0,
+					Preferred:   false,
+				},
+			},
+		},
+	)
+}
+
 func TestParseNYT(t *testing.T) {
 	testParse(
 		t,

--- a/test-html/malformed-url-test.html
+++ b/test-html/malformed-url-test.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Test Malformed URL</title>
+</head>
+<body>
+<p>
+	This is a test with a malformed image src URL <img src="%1"/>
+</p>
+
+<img />
+</body>
+</html>


### PR DESCRIPTION
Spotted an issue in the wild. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x12052d6]

goroutine 6 [running]:
net/url.(*URL).ResolveReference(0xc42008cc80, 0x0, 0x0)
	/usr/local/Cellar/go/1.8.1/libexec/src/net/url/url.go:944 +0x36
github.com/redsift/recon.(*Parser).analyzeImages.func1(0xc42008cc80, 0xc420111340, 0xc4201201c6, 0x2, 0x0, 0x0, 0x0, 0xc42001f140)
	/Users/rahul/GitHub/go/src/github.com/redsift/recon/recon.go:390 +0x6b
created by github.com/redsift/recon.(*Parser).analyzeImages
	/Users/rahul/GitHub/go/src/github.com/redsift/recon/recon.go:409 +0x169
```
`url.Parse()` was discarding the error and ended up with a nil `*URL`. Added a crafted unit test to trigger this and a guard.