### PR TITLE
Added extra guard when parsing the img url

### DIFF
--- a/recon.go
+++ b/recon.go
@@ -362,6 +362,9 @@ func parseImg(t html.Token) (i imgTag) {
 func parseImgFromData(i imgTag) (parsedImage, error) {
 	// get the image data from the url, decode it
 	parts := strings.SplitN(i.url, ";", 2)
+	if len(parts) < 2 {
+		return parsedImage{}, nil
+	}
 	header, body := parts[0], parts[1]
 	data := strings.Replace(body, "base64,", "", 1)
 	full, err := base64.StdEncoding.DecodeString(data)

--- a/recon.go
+++ b/recon.go
@@ -212,15 +212,17 @@ func (p *Parser) getHTML(url string) (*parseJob, error) {
 func (p *parseJob) tokenize() error {
 	decoder := html.NewTokenizer(p.response.Body)
 	decoder.SetMaxBuf(p.tokenMaxBuffer)
-	done := false
-	for !done {
+	loop:
+	for {
 		tt := decoder.Next()
 		switch tt {
 		case html.ErrorToken:
-			if decoder.Err() == io.EOF {
-				done = true
+			e := decoder.Err()
+			if e == io.EOF {
+				break loop
 			}
-
+			// some other kind of error
+			return e
 		case html.SelfClosingTagToken, html.StartTagToken:
 			t := decoder.Token()
 			switch t.Data {

--- a/recon.go
+++ b/recon.go
@@ -381,7 +381,12 @@ func (p *Parser) analyzeImages(baseURL *url.URL, tags []imgTag) []Image {
 
 	for _, tag := range tags {
 		go func(tag imgTag, ch chan parsedImage) {
-			u, _ := url.Parse(tag.url)
+			u, err := url.Parse(tag.url)
+			if err != nil {
+				// malformed image src
+				ch <- parsedImage{}
+				return
+			}
 			u = baseURL.ResolveReference(u)
 
 			if strings.HasPrefix(u.String(), "data:") {

--- a/recon_test.go
+++ b/recon_test.go
@@ -198,6 +198,30 @@ func TestBase64GifImage(t *testing.T) {
 	)
 }
 
+func TestBase64GifFaultyImage(t *testing.T) {
+	testParse(
+		t,
+		"http://localhost/gif-img-base64-faulty-test.html",
+		"test-html/gif-img-base64-faulty-test.html",
+		true,
+		Result{
+			Title: `base64-encoded gif faulty test`,
+			Images: []Image{
+				{
+					URL:         "",
+					Type:        "",
+					Alt:         "",
+					Width:       0,
+					Height:      0,
+					AspectRatio: 0,
+					Preferred:   false,
+				},
+			},
+		},
+	)
+}
+
+
 func TestFullParse(t *testing.T) {
 	res, err := Parse("https://section411.com/2016/10/running-the-towpath/")
 

--- a/recon_test.go
+++ b/recon_test.go
@@ -59,6 +59,31 @@ func testParse(t *testing.T, url string, local string, parseImages bool, expecte
 	}
 }
 
+func TestParseMalformed(t *testing.T) {
+	testParse(
+		t,
+		"http://localhost/malformed-url-test.html",
+		"test-html/malformed-url-test.html",
+		true,
+		Result{
+			Title:  `Test Malformed URL`,
+			Site:   ``,
+			Author: ``,
+			Images: []Image{
+				{
+					URL:         "",
+					Type:        "",
+					Alt:         "",
+					Width:       0,
+					Height:      0,
+					AspectRatio: 0,
+					Preferred:   false,
+				},
+			},
+		},
+	)
+}
+
 func TestParseNYT(t *testing.T) {
 	testParse(
 		t,

--- a/recon_test.go
+++ b/recon_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func testParse(t *testing.T, url string, local string, parseImages bool, expected Result) {
+	testParseBufferMax(t, url, local, parseImages, 0, expected)
+}
+
+func testParseBufferMax(t *testing.T, url string, local string, parseImages bool, maxBuffer int, expected Result) {
 	contents, err := ioutil.ReadFile(local)
 	if err != nil {
 		t.Errorf("Couldn't load test file")
@@ -32,6 +36,7 @@ func testParse(t *testing.T, url string, local string, parseImages bool, expecte
 		response:   testResponse.Result(),
 		metaTags:   []metaTag{},
 		imgTags:    []imgTag{},
+		tokenMaxBuffer: maxBuffer,
 	}
 
 	err = intRes.tokenize()
@@ -57,6 +62,32 @@ func testParse(t *testing.T, url string, local string, parseImages bool, expecte
 	if parseImages {
 		assert.Equal(t, expected.Images, res.Images, "Images should match")
 	}
+}
+
+func TestParseMalformedHtml(t *testing.T) {
+	testParseBufferMax(
+		t,
+		"http://localhost/malformed-html-test.html",
+		"test-html/malformed-html-test.html",
+		true,
+		5,
+		Result{
+			Title:  `Test Malformed HTML`,
+			Site:   ``,
+			Author: ``,
+			Images: []Image{
+				{
+					URL:         "",
+					Type:        "",
+					Alt:         "",
+					Width:       0,
+					Height:      0,
+					AspectRatio: 0,
+					Preferred:   false,
+				},
+			},
+		},
+	)
 }
 
 func TestParseMalformed(t *testing.T) {

--- a/test-html/gif-img-base64-faulty-test.html
+++ b/test-html/gif-img-base64-faulty-test.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>base64-encoded gif faulty test</title>
+</head>
+<body>
+<img alt="I'm surrounded by idiots" src="data:base64,asdasdfafasf">
+</body>
+</html>

--- a/test-html/malformed-html-test.html
+++ b/test-html/malformed-html-test.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Test Malformed HTML</title>
+</head>
+<body>
+<p>
+	This is a test with a malformed image src URL <img src="%1"/>
+</p>
+
+<img />
+</body>
+</html>

--- a/test-html/malformed-url-test.html
+++ b/test-html/malformed-url-test.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Test Malformed URL</title>
+</head>
+<body>
+<p>
+	This is a test with a malformed image src URL <img src="%1"/>
+</p>
+
+<img />
+</body>
+</html>


### PR DESCRIPTION
This fix resolves the following panic:
```
panic: runtime error: index out of range goroutine 23334 
[running]: github.com/jimmysawczuk/recon.parseImgFromData(0xc000d7d080, 0x72, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...) 
github.com/jimmysawczuk/recon/recon.go:365 +0x39e 
github.com/jimmysawczuk/recon.(*Parser).analyzeImages.func1(0xc001d60980, 0xc0010d22c0, 0xc000d7d080, 0x72, 0x0, 0x0, 0x0, 0xc000df0ae0) 
github.com/jimmysawczuk/recon/recon.go:404 +0x102 
created by github.com/jimmysawczuk/recon.(*Parser).analyzeImages 
github.com/jimmysawczuk/recon/recon.go:394 +0x16e
```
